### PR TITLE
docs: replace broken blog link with docs.aztec.network

### DIFF
--- a/docs/versioned_docs/version-v1.2.0/index.mdx
+++ b/docs/versioned_docs/version-v1.2.0/index.mdx
@@ -22,7 +22,7 @@ On Ethereum today, everything is publicly visible, by everyone. In the real worl
 
 To make this possible, Aztec is _not EVM compatible_ and is extending the Ethereum ecosystem by creating a new alt-VM!
 
-To learn more about how Aztec achieves these things, check out the [Aztec concepts overview](/aztec).
+To learn more about how Aztec achieves these things, check out the [https://docs.aztec.network/](/aztec).
 
 ## Start coding
 


### PR DESCRIPTION
- Old link (aztec.network/blog-what-is-aztec-testnet) returned 404  
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9fc084b0-ee9a-414b-b617-f9a645717202" />

- Updated to https://docs.aztec.network/ as the canonical docs site  
- Keeps vision.mdx pointing to a maintained resource

Please read [contributing guidelines](CONTRIBUTING.md) and remove this line.

For audit-related pull requests, please use the [audit PR template](?expand=1&template=audit.md).
